### PR TITLE
remove explicit zlib dependency

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -48,7 +48,6 @@ requirements:
     - fftw * mpi_openmpi*
     - openmpi-mpicxx
     - eigen
-    - zlib <1.3.0  # in order to work with rabbitmq of aiida-services
 
 tests:
   - package_contents:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9F076F4F7A4DF7808A2532BAE1ED8CE3CEBBD18D8313095A1050A595C74F2B5A
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR removes the previous attempt to make fans work in the presence of aiida-core-services by restricting zlib version.

Little more context: 
Pulling in aiida-core.services, which drags rabbitmq-server which needs old erlang which needs zlib=1.2.11. But fans needs hdf5 (MPI build) which in turn needs libzlib ≥1.3 and newer openssl/libcurl. Those requirements can’t coexist in one environment, so it does not work. When they update rabbitmq-server ceiling version in aiida-core feedstock it will work automatically.
