### PR TITLE
add nlohmann_json as a dependency

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9F076F4F7A4DF7808A2532BAE1ED8CE3CEBBD18D8313095A1050A595C74F2B5A
 
 build:
-  number: 1
+  number: 2
   skip:
     - win
   script:
@@ -48,6 +48,7 @@ requirements:
     - fftw * mpi_openmpi*
     - openmpi-mpicxx
     - eigen
+    - nlohmann_json
 
 tests:
   - package_contents:


### PR DESCRIPTION
This PR preemptively includes nlohmann_json as a dependency in accordance with this PR https://github.com/DataAnalyticsEngineering/FANS/pull/87. 

With the next release of FANS, the recipe will not break.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
